### PR TITLE
Fixed a typo that prevented the module from working

### DIFF
--- a/lib/Plack/Middleware/OAuth.pm
+++ b/lib/Plack/Middleware/OAuth.pm
@@ -174,7 +174,7 @@ sub request_token_v1 {
 		# failed.
 		my $plack_res = Plack::Response->new(200);
 		$plack_res->body( $res->content );
-        return $plack_res->finialize;
+        return $plack_res->finalize;
     }
 }
 


### PR DESCRIPTION
There was a minor typo on a method call that prevented the code from working as expected.
