### PR TITLE
it will throw error like

### DIFF
--- a/lib/Plack/Middleware/OAuth/Handler/AccessTokenV1.pm
+++ b/lib/Plack/Middleware/OAuth/Handler/AccessTokenV1.pm
@@ -38,10 +38,10 @@ sub run {
     #   oauth_token=
     #   oauth_verifier=
     # my $response = Net::OAuth->response( 'user auth' )->from_hash( request->params );
-    my $response = Net::OAuth->response( 'user auth' )->from_hash( { 
-        oauth_token    => $self->param('oauth_token'),
-        oauth_verifier => $self->param('oauth_verifier'),
-    });
+    # my $response = Net::OAuth->response( 'user auth' )->from_hash( { 
+    #    oauth_token    => $self->param('oauth_token'),
+    #    oauth_verifier => $self->param('oauth_verifier'),
+    # });
 
     my $request = Net::OAuth->request( 'access token' )->new( $self->build_args );
     $request->sign;
@@ -55,7 +55,7 @@ sub run {
     }
 
 
-    $response = Net::OAuth->response( 'access token' )->from_post_body( $ua_response->content );
+    my $response = Net::OAuth->response( 'access token' )->from_post_body( $ua_response->content );
 
     my $token = Plack::Middleware::OAuth::AccessToken->new( 
 		version             => $config->{version},


### PR DESCRIPTION
Parameter oauth_verifier not valid for a message of type Net::OAuth::UserAuthResponse at /usr/local/share/perl/5.10.1/Plack/Middleware/OAuth/Handler/AccessTokenV1.pm line 41
 at /usr/share/perl/5.10/Carp.pm line 44
        Carp::croak('Parameter oauth_verifier not valid for a message of type Net::OAuth::UserAuthResponse') called at /usr/local/share/perl/5.10.1/Net/OAuth/Message.pm line 241
        Net::OAuth::Message::from_hash('Net::OAuth::UserAuthResponse', 'HASH(0xb9251108)') called at /usr/local/share/perl/5.10.1/Plack/Middleware/OAuth/Handler/AccessTokenV1.pm line 41
        Plack::Middleware::OAuth::Handler::AccessTokenV1::run('Plack::Middleware::OAuth::Handler::AccessTokenV1=HASH(0xb902a308)') called at /usr/local/share/perl/5.10.1/Plack/Middleware/OAuth.pm line 159
        Plack::Middleware::OAuth::access_token('Plack::Middleware::OAuth=HASH(0xb91e5408)', 'HASH(0xb8ca2ca8)', 'Twitter') called at /usr/local/share/perl/5.10.1/Plack/Middleware/OAuth.pm line 114
        Plack::Middleware::OAuth::dispatch_oauth_call('Plack::Middleware::OAuth=HASH(0xb91e5408)', 'HASH(0xb8ca2ca8)') called at /usr/local/share/perl/5.10.1/Plack/Middleware/OAuth.pm line 120
