### PR TITLE
https://github.com/c9s/Plack-Middleware-OAuth.git

### DIFF
--- a/lib/Plack/Middleware/OAuth/Handler/AccessTokenV2.pm
+++ b/lib/Plack/Middleware/OAuth/Handler/AccessTokenV2.pm
@@ -44,7 +44,7 @@ sub get_access_token {
 	my $content_type     = $ua_response->header('Content-Type');
 	my $atkn;
 
-	if( $content_type =~ m{json} || $content_type =~ m{javascript} ) {
+	if( $content_type =~ m{json} || $content_type =~ m{javascript} || $config->{force_response_as_json} ) {
 
 		my $params = JSON::Any->new->decode( $response_content );
         $atkn = Plack::Middleware::OAuth::AccessToken->new(


### PR DESCRIPTION
$VAR1 = \bless( {
                   '_protocol' => 'HTTP/1.1',
                   '_content' => '{"access_token":"2.00WsUooC2Qf7MD7939e77fc0pxQHIqC","expires_in":86400,"uid":"2583117564"}',
                   '_rc' => '200',
                   '_headers' => bless( {
                                          'connection' => 'close',
                                          'cache-control' => 'no-cache',
                                          'date' => 'Sun, 04 Dec 2011 08:23:57 GMT',
                                          'client-ssl-cert-issuer' => '/C=US/O=GeoTrust, Inc./CN=GeoTrust SSL CA',
                                          'client-ssl-cipher' => 'AES256-SHA',
                                          'client-peer' => '180.149.135.230:443',
                                          'age' => '0',
                                          'client-date' => 'Sun, 04 Dec 2011 08:24:00 GMT',
                                          'client-ssl-warning' => 'Peer certificate not verified',
                                          'pragma' => 'No-cache',
                                          'content-type' => 'text/plain;charset=UTF-8',
                                          'server' => 'weibo',
                                          'client-response-num' => 1,
                                          'content-length' => '89',
                                          'x-varnish' => '1447771988',
                                          'via' => '1.1 varnish',
                                          'client-ssl-cert-subject' => '/serialNumber=kRDiwnZ1xCERAHgRCmvjUYLhlEfI2hJH/C=CN/ST=Beijing/L=Beijing/O=Sina.com Technology(China)Co.,ltd/OU=Sina Weibo - Platform/CN=*.weibo.com',
                                          'expires' => 'Thu, 01 Jan 1970 00:00:00 GMT'
                                        }, 'HTTP::Headers' ),

it returns the Content-Type as text/plain but indeed it's JSON. so we need a flag in config to force it parse as JSON.

Thanks.
